### PR TITLE
Fixed Comment.php not found

### DIFF
--- a/classes/WCAPI/includes.php
+++ b/classes/WCAPI/includes.php
@@ -5,7 +5,7 @@ require_once( dirname( __FILE__ ) . '/Category.php' );
 require_once( dirname( __FILE__ ) . '/Order.php' );
 require_once( dirname( __FILE__ ) . '/OrderItem.php' );
 require_once( dirname( __FILE__ ) . '/Customer.php' );
-require_once( dirname( __FILE__ ) . '/Comment.php' );
+//require_once( dirname( __FILE__ ) . '/Comment.php' );
 function __fixPHPNSGlobalStupidity() {
   global $wpdb;
   \WCAPI\Base::setAdapter( $wpdb );


### PR DESCRIPTION
Comment.php not included in the WCAPI directory, so including it returning a fatal error.
So it is not included.
